### PR TITLE
Add endpoint to update device state and enhance LockMode schema

### DIFF
--- a/surehub_api/entities/official.py
+++ b/surehub_api/entities/official.py
@@ -1,8 +1,9 @@
 from datetime import datetime, time, date
 from enum import IntEnum
-from typing import Optional, List
+from typing import Optional, List, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, GetJsonSchemaHandler
+from pydantic_core import CoreSchema
 
 
 class DeviceType(IntEnum):
@@ -59,10 +60,30 @@ class Curfew(BaseModel):
     unlock_time: Optional[time] = None
 
 
+class LockMode(IntEnum):
+    NONE = 0
+    IN = 1
+    OUT = 2
+    BOTH = 3
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> dict[str, Any]:
+        schema = handler(core_schema)
+        schema["title"] = "Lock Mode"
+        schema["description"] = (
+            "Controls the direction of locking:\n"
+            "- `0` (NONE): No locking\n"
+            "- `1` (IN): Lock inbound only\n"
+            "- `2` (OUT): Lock outbound only\n"
+            "- `3` (BOTH): Lock both directions"
+        )
+        return schema
+
+
 class DeviceControl(BaseModel):
     curfew: Curfew | List[Curfew] | None = None
     fast_polling: Optional[bool] = None
-    locking: Optional[int] = None
+    locking: Optional[LockMode] = None
     led_mode: Optional[int] = None
     pairing_mode: Optional[int] = None
 

--- a/surehub_api/routers/devices.py
+++ b/surehub_api/routers/devices.py
@@ -35,6 +35,7 @@ async def get_device_state_by_id(device_id: int) -> Any:
 
 
 @router.patch("/{device_id}/control",
+              deprecated=True,
               response_model_exclude_none=True)
 async def set_device_lock_mode(device_id: int, lock_mode: Annotated[custom.LockMode, Query(
     description="**none** = Pets can enter and leave the house \n\n"
@@ -43,6 +44,12 @@ async def set_device_lock_mode(device_id: int, lock_mode: Annotated[custom.LockM
                 "**both** = Pets can no longer enter and leave the house \n\n")
 ]) -> official.DeviceControl:
     return devices.set_lock_mode(device_id, lock_mode)
+
+
+@router.patch("/{device_id}/state",
+              response_model_exclude_none=True)
+async def update_device_state(device_id: int, device_state: official.DeviceControl) -> official.DeviceControl:
+    return devices.update_device_state(device_id, device_state)
 
 
 @router.get("/{device_id}/tags",

--- a/surehub_api/services/devices.py
+++ b/surehub_api/services/devices.py
@@ -59,6 +59,12 @@ def get_tags_of_device(device_id: int) -> List[official.DeviceTag]:
     response = requests.get(uri, headers=auth.auth_headers())
     return http_utils.extract_response_data(response)
 
+def update_device_state(device_id: int, device_state: official.DeviceControl) -> official.DeviceControl:
+    uri = f"{settings.endpoint}/api/device/{device_id}/control"
+
+    response = requests.put(uri, headers=auth.auth_headers(), json=device_state.model_dump(mode='json'))
+    return http_utils.extract_response_data(response)
+
 
 def get_tag_of_device(device_id: int, tag_id: int) -> official.DeviceTag:
     uri = f"{settings.ENDPOINT}/api/device/{device_id}/tag/{tag_id}"


### PR DESCRIPTION
This pull request introduces a new, more descriptive enum for device lock modes, updates data models to use this enum, and adds an endpoint for updating the full device state. These changes improve type safety, API clarity, and provide a more flexible interface for device control.

**API and Model Improvements:**

* Introduced the `LockMode` enum in `official.py` to replace the previous integer-based locking mode, providing clearer semantics and enhanced OpenAPI schema documentation for lock direction options.
* Updated the `DeviceControl` model to use the new `LockMode` enum for the `locking` field instead of a plain integer, improving type safety and self-documentation.
* Added a new endpoint `PATCH /{device_id}/state` in `routers/devices.py` to allow updating the full device state via the `DeviceControl` model.
* Implemented the corresponding `update_device_state` service method, which sends a PUT request to update device control settings on the backend.

**Deprecations and Typing:**

* Marked the old `PATCH /{device_id}/control` endpoint for setting lock mode as deprecated in preparation for migration to the new, more flexible endpoint.