### PR TITLE
docs(contributing): add contributing guidelines and security policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .secrets.*
 .env
 openapi.json
+/reports/
 
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing to SureHub API
+
+Thank you for taking the time to contribute! The following guidelines help keep the process smooth for everyone.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [Reporting Issues](#reporting-issues)
+- [Submitting Changes](#submitting-changes)
+- [Development Setup](#development-setup)
+- [Code Style](#code-style)
+- [Testing](#testing)
+- [Commit Messages](#commit-messages)
+
+## Code of Conduct
+
+Be respectful and constructive. Harassment or abusive behavior will not be tolerated.
+
+## Getting Started
+
+1. **Fork** the repository and create your branch from `main`.
+2. Follow the [Development Setup](#development-setup) steps below.
+3. Make your changes, add tests where appropriate, and ensure all tests pass.
+4. Open a **Pull Request** against `main`.
+
+For significant changes, open an issue first to discuss your approach before investing time in an implementation.
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/fabieu/surehub-api/issues) to report bugs or request features.
+
+For **security vulnerabilities**, follow the [Security Policy](SECURITY.md) instead — do not open a public issue.
+
+When filing a bug report include:
+
+- SureHub API version (`docker inspect` image label or `pyproject.toml`)
+- How you installed/run the API (Docker or manual)
+- Steps to reproduce
+- Expected vs. actual behaviour
+- Relevant log output (`SUREHUB_LOGLEVEL=debug`)
+
+## Submitting Changes
+
+- Keep PRs focused — one feature or fix per PR.
+- Reference related issues in the PR description (`Closes #123`).
+- Update documentation (README, OpenAPI annotations) if your change affects behaviour or configuration.
+- All CI checks must pass before a PR can be merged.
+
+## Development Setup
+
+**Prerequisites:** Python ≥ 3.10, [Poetry](https://python-poetry.org/)
+
+```bash
+git clone https://github.com/fabieu/surehub-api.git
+cd surehub-api
+
+# Install dependencies (including dev group)
+poetry install
+
+# Activate the virtual environment
+poetry shell
+
+# Copy and configure environment variables
+export SUREHUB_EMAIL=your@email.com
+export SUREHUB_PASSWORD=yourpassword
+
+# Run the API locally
+poetry run python surehub_api/main.py
+```
+
+**Docker (alternative):**
+
+```bash
+docker compose up --build
+```
+
+## Testing
+
+Run the test suite with:
+
+```bash
+poetry run pytest
+```
+
+- Add or update tests for any changed behaviour.
+- Tests live in the `tests/` directory and mirror the `surehub_api/` structure.
+- Check minimum Python version compatibility:
+  ```bash
+  poetry run vermin surehub_api/
+  ```
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
+
+Examples:
+
+```
+feat(devices): add support for feeder lid status
+fix(auth): handle expired session tokens gracefully
+docs(readme): update Docker image registry reference
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security fixes. Older versions are not actively patched.
+
+| Version  | Supported |
+|----------|-----------|
+| Latest   | Yes       |
+| < Latest | No        |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report vulnerabilities privately
+via [GitHub Security Advisories](https://github.com/fabieu/surehub-api/security/advisories/new).
+
+Include as much of the following as possible:
+
+- Type of vulnerability (e.g., credential exposure, injection, SSRF)
+- Steps to reproduce or a proof-of-concept
+- Affected component and version
+- Potential impact
+
+## Response Timeline
+
+| Milestone          | Target                |
+|--------------------|-----------------------|
+| Acknowledgement    | Within 48 hours       |
+| Initial assessment | Within 7 days         |
+| Fix or mitigation  | Dependent on severity |
+
+You will be credited in the release notes unless you request otherwise.
+
+## Scope
+
+This project proxies requests to the Sure Petcare API using credentials supplied by the user. Keep in mind:
+
+- Credentials (`SUREHUB_EMAIL`, `SUREHUB_PASSWORD`) are passed as environment variables — never commit them to version
+  control.
+- CORS is disabled by default; enabling `SUREHUB_CORS=*` broadens the attack surface.
+- This API is intended for local or trusted-network use. Exposing it publicly without authentication is not recommended.

--- a/surehub_api/services/devices.py
+++ b/surehub_api/services/devices.py
@@ -53,7 +53,7 @@ def update_device_state(device_id: int, device_state: official.DeviceControl) ->
     uri = f"{settings.endpoint}/api/device/{device_id}/control"
 
     response = requests.put(uri, headers=auth.auth_headers(), json=device_state.model_dump(mode='json'))
-    return http_utils.extract_response_data(response)
+    return response_handler.parse(response, model=official.DeviceControl)
 
 
 def get_tag_of_device(device_id: int, tag_id: int) -> official.DeviceTag:


### PR DESCRIPTION
## Summary

Adds contributor-facing documentation so external contributors have clear guidance on submitting code and reporting vulnerabilities responsibly.

## Changes

- Add `CONTRIBUTING.md` with coding standards and PR process
- Add `SECURITY.md` with the project's security policy and responsible disclosure process

Closes #143