### PR TITLE
chore(docker): add restart policy to ensure service resilience

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,3 +8,4 @@ services:
       - SUREHUB_LOGLEVEL=warning
     ports:
       - "8080:3001"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

Adds a Docker restart policy so the service automatically recovers from unexpected crashes or host reboots without manual intervention.

## Changes

- Add `restart` policy to the Docker configuration

Closes #146