### PR TITLE
feat(health): add health check endpoint and Docker healthcheck configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,7 @@ USER appuser
 
 EXPOSE 3001
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD wget --no-verbose --tries=1 -O /dev/null http://localhost:3001/health || exit 1
+
 ENTRYPOINT ["python", "surehub_api/main.py"]

--- a/surehub_api/main.py
+++ b/surehub_api/main.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from starlette.responses import RedirectResponse
 
 from surehub_api import __version__
@@ -45,9 +46,13 @@ app.include_router(dashboard.router)
 app.include_router(pets.router)
 
 
+@app.get('/health', include_in_schema=False)
+async def health():
+    return JSONResponse({"status": "ok", "version": __version__})
+
+
 # Redirect default url to docs
-@app.get('/',
-         include_in_schema=False)
+@app.get('/', include_in_schema=False)
 async def root():
     return RedirectResponse(url="/docs")
 


### PR DESCRIPTION
## Summary

Adds a `/health` HTTP endpoint and configures a Docker `HEALTHCHECK` so that Docker, orchestrators, and load balancers can verify whether the service is healthy and ready to serve traffic.

## Changes

- Add health check HTTP endpoint
- Configure `HEALTHCHECK` in the Dockerfile

Closes #147