### PR TITLE
feat(timeline): update get_timeline_of_household to return a list of dictionaries

### DIFF
--- a/surehub_api/services/timeline.py
+++ b/surehub_api/services/timeline.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 from fastapi import HTTPException
 
@@ -7,7 +8,7 @@ from surehub_api.services import api
 from surehub_api.utils import response_handler
 
 
-def get_timeline_of_household(household_id: int) -> list:
+def get_timeline_of_household(household_id: int) -> list[dict[str, Any]]:
     uri = f"{settings.endpoint}/api/timeline/household/{household_id}"
 
     result = []


### PR DESCRIPTION
## Summary

Refactors `get_timeline_of_household` to return a `list[dict]`, aligning it with the rest of the API's response conventions.

## Changes

- Update return type of `get_timeline_of_household` from its previous type to `list[dict]`

Closes #148